### PR TITLE
Move iteration over columns into pipeline.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-detect.py
+../../Library/Application Support/JetBrains/PyCharmCE2024.1/scratches/detect.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -38,8 +38,10 @@ pipeline = PiiDetectionPipeline(
     catalog=pg_catalog,
     scanners=[
         MetadataScanner(),
-        DataScanner(percentage=20, times=2,),
-    ]
+        DataScanner(),
+    ],
+    times=1,
+    percentage=20,
 )
 
 # -- Scan for PII columns.
@@ -84,11 +86,11 @@ print(json.dumps(dictionary, indent=4))
 #             "_type": "MetadataScanner"
 #         },
 #         {
-#             "times": 2,
-#             "percentage": 20,
 #             "_type": "DataScanner"
 #         }
 #     ]
+#    "times": 1,
+#    "percentage": 10
 # }
 ```
 

--- a/detectpii/model.py
+++ b/detectpii/model.py
@@ -49,7 +49,7 @@ class Scanner:
     """A PII scanner."""
 
     @abc.abstractmethod
-    def scan(self, catalog: Catalog, **kwargs):
+    def scan(self, *args, **kwargs):
         raise NotImplementedError()
 
 

--- a/detectpii/pipeline/pii_detection.py
+++ b/detectpii/pipeline/pii_detection.py
@@ -2,8 +2,8 @@ import re
 
 from attr import define, Factory
 from detectpii.catalog import CatalogT
-from detectpii.model import PiiColumn
-from detectpii.scanner import ScannerT
+from detectpii.model import PiiColumn, Column
+from detectpii.scanner import ScannerT, MetadataScanner, DataScanner
 
 
 @define(kw_only=True)
@@ -11,13 +11,14 @@ class PiiDetectionPipeline:
     catalog: CatalogT
     scanners: list[ScannerT] = Factory(list)
     ignore_column_regex: str | None = None
+    percentage: int = 10
 
     def scan(self) -> list[PiiColumn]:
         self.catalog.detect_tables()
         pii_columns = []
 
-        for scanner in self.scanners:
-            pii_columns.extend(scanner.scan(catalog=self.catalog))
+        pii_columns.extend(self._scan_data())
+        pii_columns.extend(self._scan_metadata())
 
         if self.ignore_column_regex:
             return [
@@ -27,3 +28,58 @@ class PiiDetectionPipeline:
             ]
 
         return list(set(pii_columns))
+
+    @property
+    def data_scanners(self) -> list[ScannerT]:
+        return [
+            scanner for scanner in self.scanners if isinstance(scanner, DataScanner)
+        ]
+
+    @property
+    def metadata_scanners(self) -> list[ScannerT]:
+        return [
+            scanner for scanner in self.scanners if isinstance(scanner, MetadataScanner)
+        ]
+
+    def _scan_data(self) -> list[PiiColumn]:
+        pii_columns = []
+
+        if not self.data_scanners:
+            return pii_columns
+
+        for table in self.catalog.tables:
+            for row in self.catalog.sample(
+                table=table,
+                percentage=self.percentage,
+            ):
+                for column, value in row.items():
+                    for scanner in self.data_scanners:
+                        pii_type = scanner.scan(
+                            table=table,
+                            column=Column(name=column),
+                            value=str(value),
+                        )
+
+                        if pii_type:
+                            pii_columns.extend(pii_type)
+
+        return pii_columns
+
+    def _scan_metadata(self) -> list[PiiColumn]:
+        pii_columns = []
+
+        if not self.metadata_scanners:
+            return pii_columns
+
+        for table in self.catalog.tables:
+            for column in table.columns:
+                for scanner in self.metadata_scanners:
+                    pii_type = scanner.scan(
+                        table=table,
+                        column=column,
+                    )
+
+                    if pii_type:
+                        pii_columns.extend(pii_type)
+
+        return pii_columns

--- a/detectpii/scanner/data.py
+++ b/detectpii/scanner/data.py
@@ -9,8 +9,6 @@ from detectpii.model import PiiColumn, Scanner, Column, Table
 class DataScanner(Scanner):
     """Scan the table values for PII columns."""
 
-    times: int = 1
-    percentage: int = 10
     column_value_regex_detector: Detector = ColumnValueRegexDetector()
 
     def scan(

--- a/detectpii/scanner/data.py
+++ b/detectpii/scanner/data.py
@@ -2,7 +2,7 @@ from attr import define
 
 from detectpii.detector import ColumnValueRegexDetector
 from detectpii.detector.column_name_regex import Detector
-from detectpii.model import Catalog, PiiColumn, Scanner, Column
+from detectpii.model import PiiColumn, Scanner, Column, Table
 
 
 @define(kw_only=True)
@@ -13,37 +13,27 @@ class DataScanner(Scanner):
     percentage: int = 10
     column_value_regex_detector: Detector = ColumnValueRegexDetector()
 
-    def scan(self, catalog: Catalog, **kwargs) -> list[PiiColumn]:
+    def scan(
+        self,
+        table: Table,
+        column: Column,
+        value: str,
+        **kwargs,
+    ) -> list[PiiColumn]:
         pii_columns = []
 
-        # -- Repeat the process as many times as requested
-        for _ in range(self.times):
+        pii_type = self.column_value_regex_detector.detect(
+            column=column,
+            sample=str(value),
+        )
 
-            # -- One table at a time
-            for table in catalog.tables:
+        if pii_type:
+            pii_column = PiiColumn(
+                table=table.name,
+                column=column.name,
+                pii_type=pii_type,
+            )
 
-                # -- One row at a time
-                for row in catalog.sample(
-                    table=table,
-                    percentage=self.percentage,
-                ):
-
-                    # -- One column at a time
-                    for column_name, value in row.items():
-                        column = Column(name=column_name)
-
-                        pii_type = self.column_value_regex_detector.detect(
-                            column=column,
-                            sample=str(value),
-                        )
-
-                        if pii_type:
-                            pii_column = PiiColumn(
-                                table=table.name,
-                                column=column.name,
-                                pii_type=pii_type,
-                            )
-
-                            pii_columns.append(pii_column)
+            pii_columns.append(pii_column)
 
         return pii_columns

--- a/detectpii/scanner/metadata.py
+++ b/detectpii/scanner/metadata.py
@@ -2,7 +2,7 @@ from attr import define
 
 from detectpii.detector import ColumnNameRegexDetector
 from detectpii.detector.column_name_regex import Detector
-from detectpii.model import PiiColumn, Scanner, Catalog
+from detectpii.model import PiiColumn, Scanner, Catalog, Column, Table
 
 
 @define(kw_only=True)
@@ -13,22 +13,21 @@ class MetadataScanner(Scanner):
 
     def scan(
         self,
-        catalog: Catalog,
+        table: Table,
+        column: Column,
         **kwargs,
     ) -> list[PiiColumn]:
         pii_columns = []
 
-        for table in catalog.tables:
-            for column in table.columns:
-                pii_type = self.column_name_regex_detector.detect(column)
+        pii_type = self.column_name_regex_detector.detect(column)
 
-                if pii_type:
-                    pii_column = PiiColumn(
-                        table=table.name,
-                        column=column.name,
-                        pii_type=pii_type,
-                    )
+        if pii_type:
+            pii_column = PiiColumn(
+                table=table.name,
+                column=column.name,
+                pii_type=pii_type,
+            )
 
-                    pii_columns.append(pii_column)
+            pii_columns.append(pii_column)
 
         return pii_columns


### PR DESCRIPTION
This PR moves iteration over rows and columns from individual scanners to the pipeline. This allows reusing table samples across scanners and results in the pipeline running more efficiently.

See #2 for more details.