### PR TITLE
Add SQLAlchemyCatalog

### DIFF
--- a/detectpii/catalog/hive_catalog.py
+++ b/detectpii/catalog/hive_catalog.py
@@ -3,11 +3,11 @@ from typing import Sequence
 from attrs import define
 from sqlalchemy import Engine, create_engine, text, Connection, MappingResult
 
-from detectpii.model import Catalog, Table, Column
+from detectpii.model import Catalog, Table, Column, SQLAlchemyCatalog
 
 
 @define(kw_only=True)
-class HiveCatalog(Catalog):
+class HiveCatalog(SQLAlchemyCatalog):
     user: str
     password: str
     database: str

--- a/detectpii/catalog/postgres_catalog.py
+++ b/detectpii/catalog/postgres_catalog.py
@@ -3,11 +3,12 @@ from functools import cached_property
 
 from attr import define
 from sqlalchemy import Engine, create_engine, text, URL, MappingResult
-from detectpii.model import Catalog, Column, Table
+
+from detectpii.model import Column, Table, SQLAlchemyCatalog
 
 
 @define(kw_only=True)
-class PostgresCatalog(Catalog):
+class PostgresCatalog(SQLAlchemyCatalog):
     """A collection of tables in a Postgres database and schema."""
 
     user: str

--- a/detectpii/catalog/snowflake_catalog.py
+++ b/detectpii/catalog/snowflake_catalog.py
@@ -4,11 +4,11 @@ from functools import cached_property
 from attr import define
 from sqlalchemy import Engine, create_engine, text, MappingResult
 
-from detectpii.model import Catalog, Table, Column
+from detectpii.model import SQLAlchemyCatalog, Table, Column
 
 
 @define(kw_only=True)
-class SnowflakeCatalog(Catalog):
+class SnowflakeCatalog(SQLAlchemyCatalog):
     """A collection of tables in a Snowflake database and schema."""
 
     user: str

--- a/detectpii/catalog/test_catalog.py
+++ b/detectpii/catalog/test_catalog.py
@@ -2,10 +2,10 @@ from typing import Sequence
 
 from sqlalchemy import Engine, create_engine
 
-from detectpii.model import Catalog, Table, Column
+from detectpii.model import Catalog, Table, Column, SQLAlchemyCatalog
 
 
-class TestCatalog(Catalog):
+class TestCatalog(SQLAlchemyCatalog):
     """A catalog to be used only for testing."""
 
     def engine(self) -> Engine:

--- a/detectpii/catalog/trino_catalog.py
+++ b/detectpii/catalog/trino_catalog.py
@@ -5,11 +5,11 @@ from attr import define
 from sqlalchemy import Engine, create_engine, text, Connection, Row, MappingResult
 from trino.sqlalchemy import URL
 
-from detectpii.model import Catalog, Column, Table
+from detectpii.model import Column, Table, SQLAlchemyCatalog
 
 
 @define(kw_only=True)
-class TrinoCatalog(Catalog):
+class TrinoCatalog(SQLAlchemyCatalog):
     """A collection of tables in a Trino catalog and schema."""
 
     user: str

--- a/detectpii/model.py
+++ b/detectpii/model.py
@@ -32,15 +32,19 @@ class Catalog:
     resolver: ResolverT = PlaintextResolver()
 
     @abc.abstractmethod
-    def engine(self) -> Engine:
-        raise NotImplementedError()
-
-    @abc.abstractmethod
     def detect_tables(self) -> None:
         raise NotImplementedError()
 
     @abc.abstractmethod
     def sample(self, table: Table, *args, **kwargs) -> Sequence[dict]:
+        raise NotImplementedError()
+
+
+class SQLAlchemyCatalog(Catalog):
+    """Base class for catalogs that depend on SQLAlchemy."""
+
+    @abc.abstractmethod
+    def engine(self) -> Engine:
         raise NotImplementedError()
 
 


### PR DESCRIPTION
Move engine() out of the Catalog and into SQLAlchemyCatalog.

This allows other data sources to be implemented that do not use SQLAlchemy to connect to the data source.